### PR TITLE
Add ender eye launch event

### DIFF
--- a/patches/api/0095-Add-ender-eye-launch-event.patch
+++ b/patches/api/0095-Add-ender-eye-launch-event.patch
@@ -1,0 +1,72 @@
+From 2dc970dfbe918ec4eafb8e8e12e84678f9bd17b2 Mon Sep 17 00:00:00 2001
+From: Rafi Baum <rafi@ukbaums.com>
+Date: Sat, 31 Aug 2019 23:13:10 -0400
+Subject: [PATCH] Add ender eye launch event
+
+
+diff --git a/src/main/java/network/stratus/sportpaper/api/events/EnderEyeLaunchEvent.java b/src/main/java/network/stratus/sportpaper/api/events/EnderEyeLaunchEvent.java
+new file mode 100644
+index 00000000..9255e0fb
+--- /dev/null
++++ b/src/main/java/network/stratus/sportpaper/api/events/EnderEyeLaunchEvent.java
+@@ -0,0 +1,57 @@
++package network.stratus.sportpaper.api.events;
++
++import org.bukkit.entity.EnderSignal;
++import org.bukkit.entity.HumanEntity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.EntityAction;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++
++/**
++ * Event fired when an eye of ender is launched. Bukkit does not natively fire an event when
++ * eyes of ender are launched so this event was added as a workaround since more elegant alternatives
++ * would have fundamentally altered the class structure of eyes of ender more than I would have liked.
++ *
++ * @author Rafi Baum
++ */
++public class EnderEyeLaunchEvent extends EntityEvent implements Cancellable, EntityAction {
++
++  private static HandlerList handlers = new HandlerList();
++  private boolean cancelled;
++  private HumanEntity shooter;
++
++  /**
++   * Constructor.
++   *
++   * @param what eye being launched
++   * @param shooter entity shooting the eye
++   */
++  public EnderEyeLaunchEvent(EnderSignal what, HumanEntity shooter) {
++    super(what);
++    this.shooter = shooter;
++  }
++
++  @Override
++  public boolean isCancelled() {
++    return cancelled;
++  }
++
++  @Override
++  public void setCancelled(boolean cancel) {
++    this.cancelled = cancel;
++  }
++
++  @Override
++  public HumanEntity getActor() {
++    return shooter;
++  }
++
++  @Override
++  public HandlerList getHandlers() {
++    return handlers;
++  }
++
++  public static HandlerList getHandlerList() {
++    return handlers;
++  }
++}
+-- 
+2.22.1
+

--- a/patches/server/0183-Add-ender-eye-launch-event.patch
+++ b/patches/server/0183-Add-ender-eye-launch-event.patch
@@ -1,0 +1,74 @@
+From 0efbfabf9dd0dcebb66a9b4288af900de84149ff Mon Sep 17 00:00:00 2001
+From: Rafi Baum <rafi@ukbaums.com>
+Date: Sat, 31 Aug 2019 23:13:28 -0400
+Subject: [PATCH] Add ender eye launch event
+
+
+diff --git a/src/main/java/net/minecraft/server/ItemEnderEye.java b/src/main/java/net/minecraft/server/ItemEnderEye.java
+index 8c000a1ea..4f0d06844 100644
+--- a/src/main/java/net/minecraft/server/ItemEnderEye.java
++++ b/src/main/java/net/minecraft/server/ItemEnderEye.java
+@@ -1,5 +1,9 @@
+ package net.minecraft.server;
+ 
++import network.stratus.sportpaper.api.events.EnderEyeLaunchEvent;
++import org.bukkit.craftbukkit.event.CraftEventFactory;
++import org.bukkit.entity.EnderSignal;
++
+ public class ItemEnderEye extends Item {
+ 
+     public ItemEnderEye() {
+@@ -115,6 +119,13 @@ public class ItemEnderEye extends Item {
+ 
+                 if (blockposition != null) {
+                     EntityEnderSignal entityendersignal = new EntityEnderSignal(world, entityhuman.locX, entityhuman.locY, entityhuman.locZ);
++                    // SportPaper - add ender eye event
++                    EnderEyeLaunchEvent event = CraftEventFactory
++                        .callEnderEyeLaunchEvent((EnderSignal) entityendersignal.getBukkitEntity(), entityhuman.getBukkitEntity());
++                    if (event.isCancelled()) {
++                        return itemstack;
++                    }
++                    // SportPaper - end
+ 
+                     entityendersignal.a(blockposition);
+                     world.addEntity(entityendersignal);
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 6ad5f4923..ab020c828 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -12,6 +12,7 @@ import com.google.common.base.Functions;
+ 
+ import net.minecraft.server.*;
+ 
++import network.stratus.sportpaper.api.events.EnderEyeLaunchEvent;
+ import org.bukkit.Bukkit;
+ import org.bukkit.Material;
+ import org.bukkit.Server;
+@@ -35,10 +36,12 @@ import org.bukkit.craftbukkit.util.CraftDamageSource;
+ import org.bukkit.craftbukkit.util.CraftMagicNumbers;
+ import org.bukkit.entity.Arrow;
+ import org.bukkit.entity.Creeper;
++import org.bukkit.entity.EnderSignal;
+ import org.bukkit.entity.EntityType;
+ import org.bukkit.entity.ExperienceOrb;
+ import org.bukkit.entity.Firework;
+ import org.bukkit.entity.Horse;
++import org.bukkit.entity.HumanEntity;
+ import org.bukkit.entity.LightningStrike;
+ import org.bukkit.entity.LivingEntity;
+ import org.bukkit.entity.Pig;
+@@ -1080,4 +1083,11 @@ public class CraftEventFactory {
+         world.getServer().getPluginManager().callEvent(event);
+         return event;
+     }
++
++    // SportPaper - add ender eye launch event
++    public static EnderEyeLaunchEvent callEnderEyeLaunchEvent(EnderSignal enderSignal, HumanEntity shooter) {
++        EnderEyeLaunchEvent event = new EnderEyeLaunchEvent(enderSignal, shooter);
++        Bukkit.getPluginManager().callEvent(event);
++        return event;
++    }
+ }
+-- 
+2.22.1
+

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -53,6 +53,7 @@ import ItemPotion
 import WorldGenCaves
 import WorldSettings
 import ItemFood
+import ItemEnderEye
 
 cd "$basedir/base/Paper/PaperSpigot-Server/"
 rm -rf nms-patches applyPatches.sh makePatches.sh >/dev/null 2>&1


### PR DESCRIPTION
Bukkit doesn't launch an interact event or a projectile launch event when ender signal's are launched. I considered adding a PlayerInteractEvent but figured it was just simpler to do it like this.